### PR TITLE
Fix address generation.

### DIFF
--- a/lib/address.js
+++ b/lib/address.js
@@ -460,7 +460,7 @@ Address.prototype.isPayToScriptHash = function() {
  * @returns {Buffer} Bitcoin address buffer
  */
 Address.prototype.toBuffer = function() {
-  var version = new Buffer([this.network[this.type]]);
+  var version = new Buffer(this.network[this.type].toString(16), 'hex');
   var buf = Buffer.concat([version, this.hashBuffer]);
   return buf;
 };


### PR DESCRIPTION
Zcash has two bytes as prefix. The toBuffer code from bitcore expects only one byte. This leads to invalid addresses that are missing the first byte of the zcash prefix.