### PR TITLE
Update lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "buffer-compare": "=1.0.0",
     "elliptic": "=3.0.3",
     "inherits": "=2.0.1",
-    "lodash": "=3.10.1"
+    "lodash": "=4.17.10"
   },
   "devDependencies": {
     "zcash-bitcore-build": "^0.5.4",


### PR DESCRIPTION
lodash < 4.17.5 had a vulnerability [1], hence upgrade
to a newer version.

[1]: https://nodesecurity.io/advisories/577

It would be cool if you could merge that one and do a new release.